### PR TITLE
Configure Dask to show proxied dashboard link

### DIFF
--- a/.dask/config.yaml
+++ b/.dask/config.yaml
@@ -1,0 +1,3 @@
+distributed:
+  dashboard:
+    link: "{JUPYTERHUB_BASE_URL}user/{JUPYTERHUB_USER}/proxy/{port}/status"


### PR DESCRIPTION
Test on binder: https://mybinder.org/v2/gh/willirath/dask-video-tutorial-2020/patch-1?urlpath=lab (not building because of dependency issue w/ tornado. :/)