### PR TITLE
Update enviornment and add .dask 

### DIFF
--- a/.dask/config.yaml
+++ b/.dask/config.yaml
@@ -1,0 +1,3 @@
+distributed:
+  dashboard:
+    link: "{JUPYTERHUB_BASE_URL}user/{JUPYTERHUB_USER}/proxy/{port}/status"

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,8 +2,8 @@ name: dask-tutorial
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
-  - bokeh=2.0  # Pinned until distributed 2.19 release due to breaking change
+  - python=3.8
+  - bokeh
   - asyncssh
   - dask
   - dask-ml

--- a/binder/start
+++ b/binder/start
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Replace DASK_DASHBOARD_URL with the proxy location
-sed -i -e "s|DASK_DASHBOARD_URL|/user/${JUPYTERHUB_USER}/proxy/8787|g" binder/jupyterlab-workspace.json
+sed -i -e "s|DASK_DASHBOARD_URL|${JUPYTERHUB_BASE_URL}user/${JUPYTERHUB_USER}/proxy/8787|g" binder/jupyterlab-workspace.json
 
 # Import the workspace
 jupyter lab workspaces import binder/jupyterlab-workspace.json


### PR DESCRIPTION
To get the dashboard pointing to the right link, we need to ask the `.dask` directory with the right yaml config file. I follow this  https://github.com/jrbourbeau/dask-binder-template/blob/main/.dask/config.yaml .